### PR TITLE
Make cppfs cross-compilable from linux to Windows

### DIFF
--- a/source/cppfs/include/cppfs/windows/LocalFileWatcher.h
+++ b/source/cppfs/include/cppfs/windows/LocalFileWatcher.h
@@ -7,7 +7,7 @@
 #include <vector>
 
 #define WIN32_LEAN_AND_MEAN
-#include <Windows.h>
+#include <windows.h>
 
 #include <cppfs/AbstractFileWatcherBackend.h>
 #include <cppfs/FileHandle.h>

--- a/source/cppfs/source/windows/LocalFileHandle.cpp
+++ b/source/cppfs/source/windows/LocalFileHandle.cpp
@@ -3,7 +3,7 @@
 
 #include <fstream>
 
-#include <Windows.h>
+#include <windows.h>
 
 #include <cppfs/cppfs.h>
 #include <cppfs/FilePath.h>

--- a/source/cppfs/source/windows/LocalFileIterator.cpp
+++ b/source/cppfs/source/windows/LocalFileIterator.cpp
@@ -1,7 +1,7 @@
 
 #include <cppfs/windows/LocalFileIterator.h>
 
-#include <Windows.h>
+#include <windows.h>
 
 #include <cppfs/FilePath.h>
 #include <cppfs/windows/LocalFileSystem.h>


### PR DESCRIPTION
This modification makes it possible to compile the library on a linux host for Windows via mingw. The mingw installation contains windows.h instead of Windows.h. When compiling on Windows, the case shouldn't matter, as Windows is case-insensitive.