### PR TITLE
Added support for UTF-8 on Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,7 +70,9 @@ option(OPTION_BUILD_DOCS               "Build documentation."                   
 option(OPTION_BUILD_EXAMPLES           "Build examples."                                        OFF)
 option(OPTION_BUILD_SSH_BACKEND        "Build SSH backend"                                      OFF)
 option(OPTION_FORCE_SYSTEM_DIR_INSTALL "Force system dir install"                               OFF)
-
+if(WIN32)
+	option(OPTION_WINDOWS_UTF8         "Build Windows UTF8 support"                             ON)
+endif()
 
 #
 # Declare project

--- a/source/cppfs/CMakeLists.txt
+++ b/source/cppfs/CMakeLists.txt
@@ -119,10 +119,12 @@ endif()
 if("${CMAKE_SYSTEM_NAME}" MATCHES "Windows")
     set(headers ${headers}
         ${include_path}/windows/LocalFileWatcher.h
+	    ${include_path}/windows/UTF8Handler.h
     )
 
     set(sources ${sources}
         ${source_path}/windows/LocalFileWatcher.cpp
+        ${source_path}/windows/UTF8Handler.cpp
     )
 endif()
 
@@ -188,6 +190,13 @@ set_target_properties(${target}
     SOVERSION ${META_VERSION_MAJOR}
 )
 
+if(WIN32 AND OPTION_WINDOWS_UTF8)
+	target_compile_options(${target}
+		PRIVATE
+		-DUNICODE
+		-D_UNICODE
+	)
+endif()
 
 #
 # Include directories

--- a/source/cppfs/include/cppfs/windows/UTF8Handler.h
+++ b/source/cppfs/include/cppfs/windows/UTF8Handler.h
@@ -1,0 +1,29 @@
+
+#pragma once
+
+
+#include <memory>
+
+#include <cppfs/AbstractFileSystem.h>
+
+#if defined(_UNICODE)
+    #define UTF8Convert_UTF8toW(s) UTF8Handler::utf8_to_wstring(s)
+    #define UTF8Convert_WtoUTF8(s) UTF8Handler::wstring_to_utf8(s)
+#else
+    #define UTF8Convert_UTF8toW(s) s
+    #define UTF8Convert_WtoUTF8(s) s
+#endif
+
+namespace cppfs
+{
+    /**
+    *  @brief
+    *    Windows specific UTF-8 string conversions
+    */
+    namespace UTF8Handler
+    {
+        std::wstring utf8_to_wstring(const std::string& utf8_str);
+        std::string wstring_to_utf8(const std::wstring& wstr);
+    } // namespace UTF8Handler
+
+} // namespace cppfs

--- a/source/cppfs/source/windows/LocalFileHandle.cpp
+++ b/source/cppfs/source/windows/LocalFileHandle.cpp
@@ -9,7 +9,7 @@
 #include <cppfs/FilePath.h>
 #include <cppfs/windows/LocalFileSystem.h>
 #include <cppfs/windows/LocalFileIterator.h>
-
+#include <cppfs/windows/UTF8Handler.h>
 
 namespace cppfs
 {
@@ -105,7 +105,7 @@ std::vector<std::string> LocalFileHandle::listFiles() const
     // Open directory
     WIN32_FIND_DATA findData;
     std::string query = FilePath(m_path).fullPath() + "/*";
-    HANDLE findHandle = FindFirstFileA(query.c_str(), &findData);
+    HANDLE findHandle = FindFirstFile(UTF8Convert_UTF8toW(query).c_str(), &findData);
 
     if (findHandle == INVALID_HANDLE_VALUE)
     {
@@ -116,7 +116,7 @@ std::vector<std::string> LocalFileHandle::listFiles() const
     do
     {
         // Get name
-        std::string name = findData.cFileName;
+        std::string name = UTF8Convert_WtoUTF8(findData.cFileName);
 
         // Ignore . and ..
         if (name != ".." && name != ".")
@@ -213,7 +213,7 @@ bool LocalFileHandle::createDirectory()
     if (exists()) return false;
 
     // Create directory
-    if (!CreateDirectoryA(m_path.c_str(), nullptr))
+    if (!CreateDirectory(UTF8Convert_UTF8toW(m_path).c_str(), nullptr))
     {
         return false;
     }
@@ -229,7 +229,7 @@ bool LocalFileHandle::removeDirectory()
     if (!isDirectory()) return false;
 
     // Remove directory
-    if (!RemoveDirectoryA(m_path.c_str()))
+    if (!RemoveDirectory(UTF8Convert_UTF8toW(m_path).c_str()))
     {
         return false;
     }
@@ -255,7 +255,7 @@ bool LocalFileHandle::copy(AbstractFileHandleBackend & dest)
     }
 
     // Copy file
-    if (!CopyFileA(src.c_str(), dst.c_str(), FALSE))
+    if (!CopyFile(UTF8Convert_UTF8toW(src).c_str(), UTF8Convert_UTF8toW(dst).c_str(), FALSE))
     {
         // Error!
         return false;
@@ -282,7 +282,7 @@ bool LocalFileHandle::move(AbstractFileHandleBackend & dest)
     }
 
     // Move file
-    if (!MoveFileA(src.c_str(), dst.c_str()))
+    if (!MoveFile(UTF8Convert_UTF8toW(src).c_str(), UTF8Convert_UTF8toW(dst).c_str()))
     {
         // Error!
         return false;
@@ -312,7 +312,7 @@ bool LocalFileHandle::createLink(AbstractFileHandleBackend & dest)
     }
 
     // Copy file
-    if (!CreateHardLinkA(dst.c_str(), src.c_str(), 0))
+    if (!CreateHardLink(UTF8Convert_UTF8toW(dst).c_str(), UTF8Convert_UTF8toW(src).c_str(), 0))
     {
         // Error!
         return false;
@@ -338,7 +338,7 @@ bool LocalFileHandle::createSymbolicLink(AbstractFileHandleBackend & dest)
     }
 
     // Copy file
-    if (!CreateSymbolicLinkA(dst.c_str(), src.c_str(), 0))
+    if (!CreateSymbolicLink(UTF8Convert_UTF8toW(dst).c_str(), UTF8Convert_UTF8toW(src).c_str(), 0))
     {
         // Error!
         return false;
@@ -357,7 +357,7 @@ bool LocalFileHandle::rename(const std::string & filename)
     std::string path = FilePath(FilePath(m_path).directoryPath()).resolve(filename).fullPath();
 
     // Rename
-    if (!MoveFileA(m_path.c_str(), path.c_str()))
+    if (!MoveFile(UTF8Convert_UTF8toW(m_path).c_str(), UTF8Convert_UTF8toW(path).c_str()))
     {
         // Error!
         return false;
@@ -377,7 +377,7 @@ bool LocalFileHandle::remove()
     if (!isFile()) return false;
 
     // Delete file
-    if (!DeleteFileA(m_path.c_str()))
+    if (!DeleteFile(UTF8Convert_UTF8toW(m_path).c_str()))
     {
         return false;
     }
@@ -406,7 +406,7 @@ void LocalFileHandle::readFileInfo() const
     m_fileInfo = (void *)new WIN32_FILE_ATTRIBUTE_DATA;
 
     // Get file info
-    if (!GetFileAttributesExA(m_path.c_str(), GetFileExInfoStandard, (WIN32_FILE_ATTRIBUTE_DATA*)m_fileInfo))
+    if (!GetFileAttributesEx(UTF8Convert_UTF8toW(m_path).c_str(), GetFileExInfoStandard, (WIN32_FILE_ATTRIBUTE_DATA*)m_fileInfo))
     {
         // Error!
         delete (WIN32_FILE_ATTRIBUTE_DATA *)m_fileInfo;

--- a/source/cppfs/source/windows/LocalFileIterator.cpp
+++ b/source/cppfs/source/windows/LocalFileIterator.cpp
@@ -5,6 +5,7 @@
 
 #include <cppfs/FilePath.h>
 #include <cppfs/windows/LocalFileSystem.h>
+#include <cppfs/windows/UTF8Handler.h>
 
 
 namespace cppfs
@@ -78,7 +79,7 @@ std::string LocalFileIterator::name() const
     }
 
     // Return filename of current item
-	return std::string(static_cast<WIN32_FIND_DATA *>(m_findData)->cFileName);
+	return UTF8Convert_WtoUTF8(std::wstring(static_cast<WIN32_FIND_DATA *>(m_findData)->cFileName));
 }
 
 void LocalFileIterator::next()
@@ -97,7 +98,7 @@ void LocalFileIterator::readNextEntry()
 		{
 			// Open directory
 			std::string query = FilePath(m_path).fullPath() + "/*";
-			m_findHandle = FindFirstFileA(query.c_str(), static_cast<WIN32_FIND_DATA *>(m_findData));
+			m_findHandle = FindFirstFile(UTF8Handler::utf8_to_wstring(query).c_str(), static_cast<WIN32_FIND_DATA *>(m_findData));
 
 			// Abort if directory could not be opened
 			if (m_findHandle == INVALID_HANDLE_VALUE)
@@ -122,7 +123,7 @@ void LocalFileIterator::readNextEntry()
 		m_index++;
 
 		// Get filename
-		filename = std::string(static_cast<WIN32_FIND_DATA *>(m_findData)->cFileName);
+		filename = UTF8Handler::wstring_to_utf8(std::wstring(static_cast<WIN32_FIND_DATA *>(m_findData)->cFileName));
 	} while (filename == ".." || filename == ".");
 }
 

--- a/source/cppfs/source/windows/UTF8Handler.cpp
+++ b/source/cppfs/source/windows/UTF8Handler.cpp
@@ -1,0 +1,50 @@
+
+#include <cppfs/windows/UTF8Handler.h>
+#include <windows.h>
+#include <stdexcept>
+
+
+namespace cppfs
+{
+    namespace UTF8Handler
+    {
+        std::wstring utf8_to_wstring(const std::string& utf8_str) {
+            if (utf8_str.empty()) {
+                return std::wstring();
+            }
+
+            const int wstr_len = MultiByteToWideChar(CP_UTF8, 0, utf8_str.c_str(), -1, nullptr, 0);
+            if (wstr_len == 0) {
+                throw std::runtime_error("Error converting UTF-8 string to UTF-16.");
+            }
+
+            std::wstring wstr(wstr_len, L'\0');
+
+            if (MultiByteToWideChar(CP_UTF8, 0, utf8_str.c_str(), -1, &wstr[0], wstr_len) == 0) {
+                throw std::runtime_error("Error converting UTF-8 string to UTF-16.");
+            }
+            wstr.resize(static_cast<size_t>(wstr_len) - 1); // -1 because MultiByteToWideChar includes the null terminator in its count
+
+            return wstr;
+        }
+
+        std::string wstring_to_utf8(const std::wstring& wstr) {
+            if (wstr.empty()) {
+                return std::string();
+            }
+
+            const int utf8_len = WideCharToMultiByte(CP_UTF8, 0, wstr.c_str(), -1, nullptr, 0, nullptr, nullptr);
+            if (utf8_len == 0) {
+                throw std::runtime_error("Error converting UTF-16 string to UTF-8.");
+            }
+
+            std::string utf8_str(utf8_len, '\0');
+            if (WideCharToMultiByte(CP_UTF8, 0, wstr.c_str(), -1, &utf8_str[0], utf8_len, nullptr, nullptr) == 0) {
+                throw std::runtime_error("Error converting UTF-16 string to UTF-8.");
+            }
+            utf8_str.resize(static_cast<size_t>(utf8_len) - 1); // -1 because WideCharToMultiByte includes the null terminator in its count
+
+            return utf8_str;
+        }
+    }
+} // namespace cppfs


### PR DESCRIPTION
Added support for UTF-8 strings into windows part of the code:

- cmake project now has an option OPTION_WINDOWS_UTF8 default ON to enable this feature, if set to OFF then everything works as before my changes
- all windows file system functions use the ansi or unicode variant based on the above option, if unicode mode is used then the strings sent to the Windows API calls are assumed to be UTF-8 encoded and converted to Windows native unicode format

This effectively allows ( with proper source code file encoding ) for this piece of code to work properly:

```
int main(int argc, char* argv[]) {
	auto file = cppfs::fs::open("D:\\testá.file");

	printf("File exists: %s\n", file.exists() ? "YES" : "NO");

	printf("DONE\n");
}
```

it outputs:

```
File exists: YES
DONE
```

Tested on: 
> Windows 11 Pro
> Version: 23H2
> Build: 22631.3880

With latest Visual Studio.
